### PR TITLE
Move rigidbody instead of transform

### DIFF
--- a/Assets/Scripts/BlockScripts/BlockHandler.cs
+++ b/Assets/Scripts/BlockScripts/BlockHandler.cs
@@ -36,7 +36,7 @@ public class BlockHandler : MonoBehaviour
             if (Time.time >= nextInterval) {
                 nextInterval += updateInterval;
                 if (block.GetFreeDirections()[DirectionDictionary.GetIndex("DOWN")]) {
-                    new MoveCommand(activeBlock, DirectionDictionary.GetDirection("DOWN")).Execute();
+                    new MoveCommand(activeBlock.GetComponent<Rigidbody2D>(), DirectionDictionary.GetDirection("DOWN")).Execute();
                 }
             }
         }

--- a/Assets/Scripts/Commands/MoveCommand.cs
+++ b/Assets/Scripts/Commands/MoveCommand.cs
@@ -6,18 +6,18 @@ using UnityEngine.InputSystem;
 public class MoveCommand : GameCommand
 {
     private float moveAmount = 0.5f;
-    private GameObject gameObject;
+    private Rigidbody2D rigidBody;
     private Vector3 vector;
 
-    public MoveCommand(GameObject gameObject, Vector3 vector)
+    public MoveCommand(Rigidbody2D rigidbody, Vector3 vector)
     {
-        this.gameObject = gameObject;
+        this.rigidBody = rigidbody;
         this.vector = vector;
     }
 
     public override bool Execute()
     {
-        gameObject.transform.position += vector*moveAmount;
+        rigidBody.MovePosition((Vector3)rigidBody.position + vector);
         return true;
     }
 }

--- a/Assets/Scripts/InputScripts/InputReader.cs
+++ b/Assets/Scripts/InputScripts/InputReader.cs
@@ -23,7 +23,7 @@ public class @InputReader : IInputActionCollection, IDisposable
                     ""type"": ""Button"",
                     ""id"": ""b98308cf-3f52-45e3-9eb5-86d1d683dfed"",
                     ""expectedControlType"": ""Button"",
-                    ""processors"": ""Normalize(max=1)"",
+                    ""processors"": """",
                     ""interactions"": """"
                 }
             ],

--- a/Assets/Scripts/InputScripts/InputReader.inputactions
+++ b/Assets/Scripts/InputScripts/InputReader.inputactions
@@ -10,7 +10,7 @@
                     "type": "Button",
                     "id": "b98308cf-3f52-45e3-9eb5-86d1d683dfed",
                     "expectedControlType": "Button",
-                    "processors": "Normalize(max=1)",
+                    "processors": "",
                     "interactions": ""
                 }
             ],

--- a/Assets/Scripts/InputScripts/UserInputHandler.cs
+++ b/Assets/Scripts/InputScripts/UserInputHandler.cs
@@ -12,12 +12,13 @@ public class UserInputHandler : MonoBehaviour
     public void Move(InputAction.CallbackContext context)
     {
         if (activeObject != null) {
-            Vector3 possibleMove = context.ReadValue<Vector2>();
+            Vector3Int possibleMove = (Vector3Int) Vector2Int.RoundToInt(context.ReadValue<Vector2>());
+            Debug.Log(possibleMove);
             //If the possible move is a free direction for the block, move that way
             if(DirectionDictionary.HasKey(possibleMove)) {
                 //Disgusting but takes Vector3 -> String direction -> integer index
                 if (activeObject.GetComponent<Block>().GetFreeDirections()[DirectionDictionary.GetIndex(DirectionDictionary.GetDirection(possibleMove))]) {
-                    GameCommand command = new MoveCommand(activeObject, possibleMove);
+                    GameCommand command = new MoveCommand(activeObject.GetComponent<Rigidbody2D>(), possibleMove);
                     oldCommands.Add(command);
                     command.Execute();
                 }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.5f1
-m_EditorVersionWithRevision: 2020.3.5f1 (8095aa901b9b)
+m_EditorVersion: 2020.3.7f1
+m_EditorVersionWithRevision: 2020.3.7f1 (dd97f2c94397)


### PR DESCRIPTION
Rigid body MovePostion method provides a much more reliable way of moving the blocks instead of adding a value to the transform, which can result in phasing through colliders.